### PR TITLE
add::BoardUpdate API

### DIFF
--- a/src/main/kotlin/org/example/gomstest/controller/BoardController.kt
+++ b/src/main/kotlin/org/example/gomstest/controller/BoardController.kt
@@ -38,7 +38,7 @@ class BoardController(
             .let { ResponseEntity.ok(it) }
 
     @PatchMapping("/{id}")
-    fun boardUpdate(@PathVariable id: Long,@RequestBody boardUpdateRequest: BoardUpdateRequest): ResponseEntity<Void> {
+    fun boardUpdate(@PathVariable id: Long, @Valid @RequestBody boardUpdateRequest: BoardUpdateRequest): ResponseEntity<Void> {
         boardService.boardUpdate(id, boardUpdateRequest)
         return ResponseEntity.ok().build()
     }

--- a/src/main/kotlin/org/example/gomstest/controller/BoardController.kt
+++ b/src/main/kotlin/org/example/gomstest/controller/BoardController.kt
@@ -1,12 +1,14 @@
 package org.example.gomstest.controller
 
 import jakarta.validation.Valid
+import org.example.gomstest.data.dto.request.BoardUpdateRequest
 import org.example.gomstest.data.dto.request.BoardWriteRequest
 import org.example.gomstest.data.dto.response.BoardGetResponse
 import org.example.gomstest.data.dto.response.BoardGetsResponse
 import org.example.gomstest.service.BoardService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -34,5 +36,11 @@ class BoardController(
     fun boardGets(@PathVariable id: Long): ResponseEntity<BoardGetResponse> =
         boardService.boardGet(id)
             .let { ResponseEntity.ok(it) }
+
+    @PatchMapping("/{id}")
+    fun boardUpdate(@PathVariable id: Long,@RequestBody boardUpdateRequest: BoardUpdateRequest): ResponseEntity<Void> {
+        boardService.boardUpdate(id, boardUpdateRequest)
+        return ResponseEntity.ok().build()
+    }
 
 }

--- a/src/main/kotlin/org/example/gomstest/data/dto/request/BoardUpdateRequest.kt
+++ b/src/main/kotlin/org/example/gomstest/data/dto/request/BoardUpdateRequest.kt
@@ -16,8 +16,8 @@ data class BoardUpdateRequest(
     fun toEntity(board: Board): Board =
         Board(
             id = board.id,
-            title = board.title,
-            content = board.content,
-            category = board.category
+            title = title,
+            content = content,
+            category = category
         )
 }

--- a/src/main/kotlin/org/example/gomstest/data/dto/request/BoardUpdateRequest.kt
+++ b/src/main/kotlin/org/example/gomstest/data/dto/request/BoardUpdateRequest.kt
@@ -1,0 +1,23 @@
+package org.example.gomstest.data.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.example.gomstest.data.entity.Board
+import org.example.gomstest.data.enums.Major
+
+data class BoardUpdateRequest(
+    @field:NotBlank
+    val title: String,
+    @field:NotBlank
+    val content: String,
+    @field:NotNull
+    val category: Major
+) {
+    fun toEntity(board: Board): Board =
+        Board(
+            id = board.id,
+            title = board.title,
+            content = board.content,
+            category = board.category
+        )
+}

--- a/src/main/kotlin/org/example/gomstest/service/BoardService.kt
+++ b/src/main/kotlin/org/example/gomstest/service/BoardService.kt
@@ -1,5 +1,6 @@
 package org.example.gomstest.service
 
+import org.example.gomstest.data.dto.request.BoardUpdateRequest
 import org.example.gomstest.data.dto.request.BoardWriteRequest
 import org.example.gomstest.data.dto.response.BoardGetResponse
 import org.example.gomstest.data.dto.response.BoardGetsResponse
@@ -8,4 +9,5 @@ interface BoardService {
     fun boardWrite(boardWriteRequest: BoardWriteRequest)
     fun boardGets(): List<BoardGetsResponse>
     fun boardGet(id: Long): BoardGetResponse
+    fun boardUpdate(id: Long, boardUpdateRequest: BoardUpdateRequest)
 }

--- a/src/main/kotlin/org/example/gomstest/service/impl/BoardServiceImpl.kt
+++ b/src/main/kotlin/org/example/gomstest/service/impl/BoardServiceImpl.kt
@@ -1,6 +1,7 @@
 package org.example.gomstest.service.impl
 
 import jakarta.transaction.Transactional
+import org.example.gomstest.data.dto.request.BoardUpdateRequest
 import org.example.gomstest.data.dto.request.BoardWriteRequest
 import org.example.gomstest.data.dto.response.BoardGetResponse
 import org.example.gomstest.data.dto.response.BoardGetsResponse
@@ -35,6 +36,13 @@ class BoardServiceImpl(
             ?:throw RuntimeException()
 
         return BoardGetResponse(board)
+    }
+
+    override fun boardUpdate(id: Long, boardUpdateRequest: BoardUpdateRequest) {
+        val board = boardRepository.findByIdOrNull(id)
+            ?:throw RuntimeException()
+
+        boardRepository.save(boardUpdateRequest.toEntity(board))
     }
 
 }


### PR DESCRIPTION
* Path로 id를 받고 Dto를 사용하여 수정할 내용을 body로 받는다.
* 받은 body를 원래 게시글의 내용과 수정하여 DB에 저장한다.